### PR TITLE
Batch Responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/management-sdk",
-  "version": "0.1.26",
+  "version": "0.1.30",
   "description": "Agility CMS Tyescript SDK for Management API.",
   "repository": {
     "type": "git",
@@ -27,9 +27,9 @@
   "author": "Agility CMS",
   "contributors": [
     "Joel Varty",
+    "Aaron Taylor",
     "Mohit Vashishtha",
-    "Kevin Tran",
-    "Aaron Taylor"
+    "Kevin Tran"
   ],
   "license": "MIT",
   "dependencies": {

--- a/src/apiMethods/contentMethods.ts
+++ b/src/apiMethods/contentMethods.ts
@@ -7,6 +7,7 @@ import { ContentListFilterModel } from "../models/contentListFilterModel";
 import { ContentItemHistory } from "../models/contentItemHistory";
 import { ItemComments } from "../models/itemComments";
 import { ListParams } from "../models/listParams";
+import { Batch } from "../models/batch";
 
 export class ContentMethods {
     _options!: Options;
@@ -30,103 +31,91 @@ export class ContentMethods {
         }
     }
 
-    async publishContent(contentID: number, guid: string, locale: string, comments: string = null) {
+    async publishContent(contentID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/${contentID}/publish?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to publish the content for id: ${contentID}`, err);
         }
     }
 
-    async unPublishContent(contentID: number, guid: string, locale: string, comments: string = null) {
+    async unPublishContent(contentID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/${contentID}/unpublish?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to un-publish the content for id: ${contentID}`, err);
         }
     }
 
-    async contentRequestApproval(contentID: number, guid: string, locale: string, comments: string = null) {
+    async contentRequestApproval(contentID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/${contentID}/request-approval?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to request approval the content for id: ${contentID}`, err);
         }
     }
 
-    async approveContent(contentID: number, guid: string, locale: string, comments: string = null) {
+    async approveContent(contentID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/${contentID}/approve?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to approve the content for id: ${contentID}`, err);
         }
     }
 
-    async declineContent(contentID: number, guid: string, locale: string, comments: string = null) {
+    async declineContent(contentID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/${contentID}/decline?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to decline the content for id: ${contentID}`, err);
         }
     }
 
-    async deleteContent(contentID: number, guid: string, locale: string, comments: string = null) {
+    async deleteContent(contentID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/${contentID}?comments=${comments}`;
             const resp = await this._clientInstance.executeDelete(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to delete the content for id: ${contentID}`, err);
         }
     }
 
-    async saveContentItem(contentItem: ContentItem, guid: string, locale: string) {
+    async saveContentItem(contentItem: ContentItem, guid: string, locale: string): Promise<Batch> {
         try {
             let apiPath = `${locale}/item`;
             const resp = await this._clientInstance.executePost(apiPath, guid, this._options.token, contentItem);
@@ -134,20 +123,13 @@ export class ContentMethods {
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
 
-            // Aaaron May 1 2025 - if the batch has error data, return the batch not just the -1 contentID
-            if (batch.errorData) {
-                return batch;
-            }
-
-            let contentIDs: number[] = [];
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            return batch;
         } catch (err) {
             throw new Exception('Unable to create content.', err);
         }
     }
 
-    async saveContentItems(contentItems: ContentItem[], guid: string, locale: string) {
+    async saveContentItems(contentItems: ContentItem[], guid: string, locale: string): Promise<Batch> {
         try {
             let apiPath = `${locale}/item/multi`;
             const resp = await this._clientInstance.executePost(apiPath, guid, this._options.token, contentItems);
@@ -155,15 +137,7 @@ export class ContentMethods {
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
 
-            // Aaaron May 1 2025 - if the batch has error data, return the batch not just the -1 contentID
-            if (batch.errorData) {
-                return batch;
-            }
-
-            let contentIDs: number[] = [];
-
-            batch.items.forEach(element => contentIDs.push(element.itemID));
-            return contentIDs;
+            return batch;
         } catch (err) {
             throw new Exception('Unable to create contents.', err);
         }

--- a/src/apiMethods/pageMethods.ts
+++ b/src/apiMethods/pageMethods.ts
@@ -8,6 +8,7 @@ import { PageModel } from "../models/pageModel";
 import { ContentSectionDefinition } from "../models/contentSectionDefinition";
 import { PageHistory } from "../models/pageHistory";
 import { ItemComments } from "../models/itemComments";
+import { Batch } from "../models/batch";
 
 export class PageMethods {
     _options!: Options;
@@ -110,103 +111,91 @@ export class PageMethods {
         }
     }
 
-    async publishPage(pageID: number, guid: string, locale: string, comments: string = null) {
+    async publishPage(pageID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/page/${pageID}/publish?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let pageIDs: number[] = [];
-
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to publish the page for id: ${pageID}`, err);
         }
     }
 
-    async unPublishPage(pageID: number, guid: string, locale: string, comments: string = null) {
+    async unPublishPage(pageID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/page/${pageID}/unpublish?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let pageIDs: number[] = [];
-
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to un-publish the page for id: ${pageID}`, err);
         }
     }
 
-    async pageRequestApproval(pageID: number, guid: string, locale: string, comments: string = null) {
+    async pageRequestApproval(pageID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/page/${pageID}/request-approval?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let pageIDs: number[] = [];
-
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to request approval the page for id: ${pageID}`, err);
         }
     }
 
-    async approvePage(pageID: number, guid: string, locale: string, comments: string = null) {
+    async approvePage(pageID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/page/${pageID}/approve?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let pageIDs: number[] = [];
-
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to approve the page for id: ${pageID}`, err);
         }
     }
 
-    async declinePage(pageID: number, guid: string, locale: string, comments: string = null) {
+    async declinePage(pageID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/page/${pageID}/decline?comments=${comments}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let pageIDs: number[] = [];
-
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to decline the page for id: ${pageID}`, err);
         }
     }
 
-    async deletePage(pageID: number, guid: string, locale: string, comments: string = null) {
+    async deletePage(pageID: number, guid: string, locale: string, comments: string = null): Promise<Batch> {
         try {
             let apiPath = `${locale}/page/${pageID}?comments=${comments}`;
             const resp = await this._clientInstance.executeDelete(apiPath, guid, this._options.token);
 
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
-            let pageIDs: number[] = [];
-
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to delete the page for id: ${pageID}`, err);
         }
     }
 
-    async savePage(pageItem: PageItem, guid: string, locale: string, parentPageID: number = -1, placeBeforePageItemID: number = -1) {
+    async savePage(pageItem: PageItem, guid: string, locale: string, parentPageID: number = -1, placeBeforePageItemID: number = -1): Promise<Batch> {
         try {
             let apiPath = `${locale}/page?parentPageID=${parentPageID}&placeBeforePageItemID=${placeBeforePageItemID}`;
             const resp = await this._clientInstance.executePost(apiPath, guid, this._options.token, pageItem);
@@ -214,14 +203,7 @@ export class PageMethods {
             let batchID = resp.data as number;
             var batch = await this._batchMethods.Retry(async () => await this._batchMethods.getBatch(batchID, guid));
 
-            // Aaaron May 1 2025 - if the batch has error data, return the batch not just the -1 pageID
-            if (batch.errorData) {
-                return batch;
-            }
-
-            let pageIDs: number[] = [];
-            batch.items.forEach(element => pageIDs.push(element.itemID));
-            return pageIDs;
+            return batch;
         } catch (err) {
             throw new Exception(`Unable to create page. ${err}`, err);
         }


### PR DESCRIPTION
This PR makes a fundamental change to the way batched content and pages are handled in the SDK. Essentially we were over simplifying by returning an array of ID's with -1 denoting failures, however this meant we were dropping critical errorData from the API responses. 

Instead of type switching responses, causing more end user handling, I have standardized the SDK to return the full batch. 

This takes place after we poll the batch for completion. 