### PR TITLE
fix(pageMethods): fix getPageComments calling /history instead of /comments

### DIFF
--- a/src/apiMethods/pageMethods.ts
+++ b/src/apiMethods/pageMethods.ts
@@ -306,7 +306,7 @@ export class PageMethods {
 
     async getPageComments(locale: string, guid: string, pageID: number, take: number = 50, skip: number = 0) {
         try {
-            let apiPath = `${locale}/item/${pageID}/history?take=${take}&skip=${skip}`;
+            let apiPath = `${locale}/item/${pageID}/comments?take=${take}&skip=${skip}`;
             const resp = await this._clientInstance.executeGet(apiPath, guid, this._options.token);
 
             return resp.data as ItemComments;

--- a/src/apiMethods/pageMethods.ts
+++ b/src/apiMethods/pageMethods.ts
@@ -311,7 +311,7 @@ export class PageMethods {
 
             return resp.data as ItemComments;
         } catch (err) {
-            throw new Exception(`Unable to retrieve history for pageID: ${pageID}`)
+            throw new Exception(`Unable to retrieve comments for pageID: ${pageID}`)
         }
     }
 }


### PR DESCRIPTION
## Summary
`getPageComments()` was calling `/${locale}/item/${pageID}/history` instead of `/${locale}/item/${pageID}/comments` — a copy-paste bug from `getPageHistory`. Single line fix restoring correct behaviour.

## Code Changes
- `src/apiMethods/pageMethods.ts` line 309: changed `/history` to `/comments` in the API path

## Documentation Changes
- `docs/page-methods.md` does not exist — no doc changes required

## API Reference
`GET /${locale}/item/${pageID}/comments` (ContentItemController)

## Drift Report Item
`DWI-001`: Fix getPageComments bug — calls history endpoint instead of comments
Jira: https://agilitycms.atlassian.net/browse/PROD-822

## Test Plan
- [x] Build passes (`tsc --noEmit`)
- [ ] Manual verification against API

---
Generated from drift analysis by `/fix-sdk-drift`