### PR TITLE
Surface Management API error status + response body in Exception message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/management-sdk",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Agility CMS Tyescript SDK for Management API.",
   "repository": {
     "type": "git",

--- a/src/models/exception.ts
+++ b/src/models/exception.ts
@@ -1,9 +1,29 @@
 export class Exception extends Error {
 
 	constructor(message: string, inner?: Error) {
-		super(message)
+		const anyErr = inner as any
+		const status = anyErr?.response?.status
+		const data = anyErr?.response?.data
+		const detail = data
+			? (typeof data === "string"
+				? data
+				: (data.exceptionMessage ?? data.message ?? JSON.stringify(data)))
+			: anyErr?.message
+
+		// Surface the server's status + response body in the message. The Management API
+		// (and other callers) only read Error.message, so folding the response detail in here
+		// turns an opaque "Unable to save the container" into
+		// "Unable to save the container (HTTP 500): <server message>".
+		super(detail ? `${message}${status ? ` (HTTP ${status})` : ""}: ${detail}` : message)
+
 		this.innerError = inner
+		this.statusCode = status
+		this.responseData = data
 	}
 
 	innerError?: Error
+	/** HTTP status code from the underlying response, when available. */
+	statusCode?: number
+	/** Raw response body from the underlying response, when available. */
+	responseData?: unknown
 }


### PR DESCRIPTION
## What
`Exception` now folds the underlying HTTP **status** and **response body** into `message`, and exposes `statusCode` / `responseData` for structured access.

**Before:** `Unable to save the container`
**After:** `Unable to save the container (HTTP 500): Error while saving the Content Container.`
## Changes
- `src/models/exception.ts`: constructor folds `inner.response.status` + `inner.response.data` (string, or `exceptionMessage`/`message`, else JSON) into the message; adds `statusCode?` and `responseData?`.
- `package.json`: `0.1.33` → `0.1.34`.

## Compatibility & scope
- Backward compatible: `message` still begins with the original text; `innerError` is unchanged.
