### PR TITLE
Fix publish workflow: Node 24 (npm@latest requires Node >= 22)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for Trusted Publisher OIDC support


### PR DESCRIPTION
npm install -g npm@latest` now installs npm 12, which requires Node >= 22, but the workflow pinned Node 20 